### PR TITLE
Some updates to language used in wallet

### DIFF
--- a/app/components/AddAddressModal.js
+++ b/app/components/AddAddressModal.js
@@ -129,14 +129,14 @@ export default function AddAddress(props: Props) {
             />
             <div className={styles.fundraiserPasswordContainer}>
               <TextField
-                floatingLabelText="Pass Phrase"
+                floatingLabelText="Passphrase"
                 type="password"
                 style={{ width: '45%' }}
                 value={passPhrase}
                 onChange={(_, newPassPhrase) => updatePassPhrase(newPassPhrase)}
               />
               <TextField
-                floatingLabelText="Confirm Pass Phrase"
+                floatingLabelText="Confirm Passphrase"
                 type="password"
                 style={{ width: '45%' }}
                 onChange={(_, newPassPhrase) =>
@@ -163,7 +163,7 @@ export default function AddAddress(props: Props) {
               onChange={(_, newActivationCode) => updateActivationCode(newActivationCode)}
             />
             <TextField
-              floatingLabelText="Username"
+              floatingLabelText="Email"
               style={{ width: '100%' }}
               value={username}
               onChange={(_, newUsername) => updateUsername(newUsername)}

--- a/app/components/CreateAccountModal.js
+++ b/app/components/CreateAccountModal.js
@@ -101,7 +101,7 @@ class CreateAccountModal extends Component<Props> {
         </div>
         <div className={styles.amountAndFeeContainer}>
           <TextField
-            floatingLabelText="Pass Phrase"
+            floatingLabelText="Passphrase"
             type="password"
             style={{ width: '45%' }}
             default="0"
@@ -109,7 +109,7 @@ class CreateAccountModal extends Component<Props> {
             onChange={this.updatePassPhrase}
           />
           <TextField
-            floatingLabelText="Confirm Pass Phrase"
+            floatingLabelText="Confirm Passphrase"
             type="password"
             style={{ width: '45%' }}
             default="0"

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -123,7 +123,7 @@ class Home extends Component<Props> {
           <h3 className={styles.walletTitle}>Create a new wallet</h3>
           <div className={styles.importButtonContainer}>
             <Button buttonTheme="secondary" onClick={this.saveFile} small>
-              Select File
+              Create Wallet File
             </Button>
             <span className={styles.walletFileName}>{walletFileName}</span>
           </div>

--- a/app/constants/AddAddressTypes.js
+++ b/app/constants/AddAddressTypes.js
@@ -1,6 +1,6 @@
 export default {
   FUNDRAISER: 'Import from fundraiser',
-  SEED_PHRASE: 'Unlock with mnemonic',
+  SEED_PHRASE: 'Import with mnemonic',
   PRIVATE_KEY: 'Import key pair',
   GENERATE_MNEMONIC: 'Create'
 };


### PR DESCRIPTION
- ```Pass Phrase``` should be ```Passphrase```
- ```Select File``` is confusing for users creating a new wallet.  There is no file yet.  Change to ```Create Wallet File``` similar to import page.
-  ```Username``` is confusing, it's an email address.
- ```Import``` instead of ```Unlock``` for mnemonic.