### PR TITLE
Fixed issue #153: Redux persisting state of tabs across different addresses

### DIFF
--- a/app/components/ActionPanel.js
+++ b/app/components/ActionPanel.js
@@ -104,6 +104,9 @@ type State = {
   currentPage: number
 };
 
+const delegateAddressTabs = [TRANSACTIONS, SEND, RECEIVE];
+const managerAddresssTabs = [TRANSACTIONS, SEND, RECEIVE, DELEGATE];
+
 class ActionPanel extends Component<Props, State> {
   props: Props;
 
@@ -114,6 +117,24 @@ class ActionPanel extends Component<Props, State> {
 
   handleLinkPress = tab => {
     this.setState({ activeTab: tab })
+  }
+
+  static getDerivedStateFromProps(prevProps, prevState) {
+    const { selectedAccountHash, selectedParentHash } = prevProps;
+    const isManagerAddress = selectedAccountHash === selectedParentHash;
+    const { activeTab } = prevState;
+
+    const tabs = isManagerAddress ?  delegateAddressTabs : managerAddresssTabs;
+
+    // activeTab may be set to something which isn't a valid tab for the current
+    // view, so set it to the first tab as default
+    if (!tabs.includes(activeTab)) {
+      return {
+        activeTab: tabs[0],
+        currentPage: 1
+      };
+    }
+    return null;
   }
 
   renderSection = () => {
@@ -169,7 +190,7 @@ class ActionPanel extends Component<Props, State> {
     const { activeTab } = this.state;
     const isReady = selectedAccount.get('status') === READY;
 
-    const tabs = isManagerAddress ? [TRANSACTIONS, SEND, RECEIVE] : [TRANSACTIONS, SEND, RECEIVE, DELEGATE];
+    const tabs = isManagerAddress ?  delegateAddressTabs : managerAddresssTabs;
 
     return (
       <Container>


### PR DESCRIPTION
Added getDerivedStateFromProps to fix the activeTab when switching from delegateAddressTab to managerAddresssTab