### PR TITLE
Fix typo

### DIFF
--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -316,7 +316,7 @@ class Home extends Component<Props> {
               Create Wallet
             </CustomButton>
             <Tip>
-              Want to import your funraiser account?
+              Want to import your fundraiser account?
               <Strong> Create a wallet </Strong>
               first.
             </Tip>


### PR DESCRIPTION
This fixes a typo: 'fundraiser' vs 'funraiser'